### PR TITLE
UX improvement for non-linked date-range picker when max date is set

### DIFF
--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -27,9 +27,9 @@
         // Browser globals
         root.daterangepicker = factory(root.moment, root.jQuery);
     }
-}(this, function(moment, $) {
+  }(this, function(moment, $) {
     var DateRangePicker = function(element, options, cb) {
-
+  
         //default settings for options
         this.parentEl = 'body';
         this.element = $(element);
@@ -54,19 +54,19 @@
         this.disableInput = false;
         this.emitChangeOnSameDate = false;
         this.ranges = {};
-
+  
         this.opens = 'right';
         if (this.element.hasClass('pull-right'))
             this.opens = 'left';
-
+  
         this.drops = 'down';
         if (this.element.hasClass('dropup'))
             this.drops = 'up';
-
+  
         this.buttonClasses = 'btn btn-sm';
         this.applyClass = 'btn-success';
         this.cancelClass = 'btn-default';
-
+  
         this.locale = {
             direction: 'ltr',
             format: moment.localeData().longDateFormat('L'),
@@ -79,22 +79,22 @@
             monthNames: moment.monthsShort(),
             firstDay: moment.localeData().firstDayOfWeek()
         };
-
+  
         this.callback = function() { };
-
+  
         //some state information
         this.isShowing = false;
         this.leftCalendar = {};
         this.rightCalendar = {};
-
+  
         //custom options from user
         if (typeof options !== 'object' || options === null)
             options = {};
-
+  
         //allow setting options with data attributes
         //data-api options will be overwritten with custom javascript options
         options = $.extend(this.element.data(), options);
-
+  
         //html template for the picker UI
         if (typeof options.template !== 'string' && !(options.template instanceof $))
             options.template = '<div class="daterangepicker dropdown-menu">' +
@@ -127,43 +127,43 @@
                     '</div>' +
                 '</div>' +
             '</div>';
-
+  
         this.parentEl = (options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl);
         this.container = $(options.template).appendTo(this.parentEl);
-
+  
         //
         // handle all the possible options overriding defaults
         //
-
+  
         if (typeof options.locale === 'object') {
-
+  
             if (typeof options.locale.direction === 'string')
                 this.locale.direction = options.locale.direction;
-
+  
             if (typeof options.locale.format === 'string')
                 this.locale.format = options.locale.format;
-
+  
             if (typeof options.locale.separator === 'string')
                 this.locale.separator = options.locale.separator;
-
+  
             if (typeof options.locale.daysOfWeek === 'object')
                 this.locale.daysOfWeek = options.locale.daysOfWeek.slice();
-
+  
             if (typeof options.locale.monthNames === 'object')
               this.locale.monthNames = options.locale.monthNames.slice();
-
+  
             if (typeof options.locale.firstDay === 'number')
               this.locale.firstDay = options.locale.firstDay;
-
+  
             if (typeof options.locale.applyLabel === 'string')
               this.locale.applyLabel = options.locale.applyLabel;
-
+  
             if (typeof options.locale.cancelLabel === 'string')
               this.locale.cancelLabel = options.locale.cancelLabel;
-
+  
             if (typeof options.locale.weekLabel === 'string')
               this.locale.weekLabel = options.locale.weekLabel;
-
+  
             if (typeof options.locale.customRangeLabel === 'string'){
                 //Support unicode chars in the custom range name.
                 var elem = document.createElement('textarea');
@@ -173,114 +173,114 @@
             }
         }
         this.container.addClass(this.locale.direction);
-
+  
         if (typeof options.startDate === 'string')
             this.startDate = moment(options.startDate, this.locale.format);
-
+  
         if (typeof options.endDate === 'string')
             this.endDate = moment(options.endDate, this.locale.format);
-
+  
         if (typeof options.minDate === 'string')
             this.minDate = moment(options.minDate, this.locale.format);
-
+  
         if (typeof options.maxDate === 'string')
             this.maxDate = moment(options.maxDate, this.locale.format);
-
+  
         if (typeof options.startDate === 'object')
             this.startDate = moment(options.startDate);
-
+  
         if (typeof options.endDate === 'object')
             this.endDate = moment(options.endDate);
-
+  
         if (typeof options.minDate === 'object')
             this.minDate = moment(options.minDate);
-
+  
         if (typeof options.maxDate === 'object')
             this.maxDate = moment(options.maxDate);
-
+  
         // sanity check for bad options
         if (this.minDate && this.startDate.isBefore(this.minDate))
             this.startDate = this.minDate.clone();
-
+  
         // sanity check for bad options
         if (this.maxDate && this.endDate.isAfter(this.maxDate))
             this.endDate = this.maxDate.clone();
-
+  
         if (typeof options.applyClass === 'string')
             this.applyClass = options.applyClass;
-
+  
         if (typeof options.cancelClass === 'string')
             this.cancelClass = options.cancelClass;
-
+  
         if (typeof options.dateLimit === 'object')
             this.dateLimit = options.dateLimit;
-
+  
         if (typeof options.opens === 'string')
             this.opens = options.opens;
-
+  
         if (typeof options.drops === 'string')
             this.drops = options.drops;
-
+  
         if (typeof options.showWeekNumbers === 'boolean')
             this.showWeekNumbers = options.showWeekNumbers;
-
+  
         if (typeof options.showISOWeekNumbers === 'boolean')
             this.showISOWeekNumbers = options.showISOWeekNumbers;
-
+  
         if (typeof options.buttonClasses === 'string')
             this.buttonClasses = options.buttonClasses;
-
+  
         if (typeof options.buttonClasses === 'object')
             this.buttonClasses = options.buttonClasses.join(' ');
-
+  
         if (typeof options.showDropdowns === 'boolean')
             this.showDropdowns = options.showDropdowns;
-
+  
         if (typeof options.showCustomRangeLabel === 'boolean')
             this.showCustomRangeLabel = options.showCustomRangeLabel;
-
+  
         if (typeof options.singleDatePicker === 'boolean') {
             this.singleDatePicker = options.singleDatePicker;
             if (this.singleDatePicker)
                 this.endDate = this.startDate.clone();
         }
-
+  
         if (typeof options.timePicker === 'boolean')
             this.timePicker = options.timePicker;
-
+  
         if (typeof options.timePickerSeconds === 'boolean')
             this.timePickerSeconds = options.timePickerSeconds;
-
+  
         if (typeof options.timePickerIncrement === 'number')
             this.timePickerIncrement = options.timePickerIncrement;
-
+  
         if (typeof options.timePicker24Hour === 'boolean')
             this.timePicker24Hour = options.timePicker24Hour;
-
+  
         if (typeof options.autoApply === 'boolean')
             this.autoApply = options.autoApply;
-
+  
         if (typeof options.autoUpdateInput === 'boolean')
             this.autoUpdateInput = options.autoUpdateInput;
-
+  
         if (typeof options.disableInput === 'boolean')
             this.disableInput = options.disableInput;
-
+  
         if (typeof options.emitChangeOnSameDate === 'boolean')
             this.emitChangeOnSameDate = options.emitChangeOnSameDate;
-
+  
         if (typeof options.linkedCalendars === 'boolean')
             this.linkedCalendars = options.linkedCalendars;
-
+  
         if (typeof options.isInvalidDate === 'function')
             this.isInvalidDate = options.isInvalidDate;
-
+  
         if (typeof options.isCustomDate === 'function')
             this.isCustomDate = options.isCustomDate;
-
+  
         if (typeof options.alwaysShowCalendars === 'boolean')
             this.alwaysShowCalendars = options.alwaysShowCalendars;
-
+  
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
             var iterator = this.locale.firstDay;
@@ -289,17 +289,17 @@
                 iterator--;
             }
         }
-
+  
         var start, end, range;
-
+  
         //if no start/end dates set, check if an input element contains initial values
         if (typeof options.startDate === 'undefined' && typeof options.endDate === 'undefined') {
             if ($(this.element).is('input[type=text]')) {
                 var val = $(this.element).val(),
                     split = val.split(this.locale.separator);
-
+  
                 start = end = null;
-
+  
                 if (split.length == 2) {
                     start = moment(split[0], this.locale.format);
                     end = moment(split[1], this.locale.format);
@@ -313,45 +313,45 @@
                 }
             }
         }
-
+  
         if (typeof options.ranges === 'object') {
             for (range in options.ranges) {
-
+  
                 if (typeof options.ranges[range][0] === 'string')
                     start = moment(options.ranges[range][0], this.locale.format);
                 else
                     start = moment(options.ranges[range][0]);
-
+  
                 if (typeof options.ranges[range][1] === 'string')
                     end = moment(options.ranges[range][1], this.locale.format);
                 else
                     end = moment(options.ranges[range][1]);
-
+  
                 // If the start or end date exceed those allowed by the minDate or dateLimit
                 // options, shorten the range to the allowable period.
                 if (this.minDate && start.isBefore(this.minDate))
                     start = this.minDate.clone();
-
+  
                 var maxDate = this.maxDate;
                 if (this.dateLimit && maxDate && start.clone().add(this.dateLimit).isAfter(maxDate))
                     maxDate = start.clone().add(this.dateLimit);
                 if (maxDate && end.isAfter(maxDate))
                     end = maxDate.clone();
-
+  
                 // If the end of the range is before the minimum or the start of the range is
                 // after the maximum, don't display this range option at all.
-                if ((this.minDate && end.isBefore(this.minDate, this.timepicker ? 'minute' : 'day')) 
+                if ((this.minDate && end.isBefore(this.minDate, this.timepicker ? 'minute' : 'day'))
                   || (maxDate && start.isAfter(maxDate, this.timepicker ? 'minute' : 'day')))
                     continue;
-
+  
                 //Support unicode chars in the range names.
                 var elem = document.createElement('textarea');
                 elem.innerHTML = range;
                 var rangeHtml = elem.value;
-
+  
                 this.ranges[rangeHtml] = [start, end];
             }
-
+  
             var list = '<ul>';
             for (range in this.ranges) {
                 list += '<li data-range-key="' + range + '">' + range + '</li>';
@@ -362,27 +362,27 @@
             list += '</ul>';
             this.container.find('.ranges').prepend(list);
         }
-
+  
         if (typeof cb === 'function') {
             this.callback = cb;
         }
-
+  
         if (!this.timePicker) {
             this.startDate = this.startDate.startOf('day');
             this.endDate = this.endDate.endOf('day');
             this.container.find('.calendar-time').hide();
         }
-
+  
         //can't be used together for now
         if (this.timePicker && this.autoApply)
             this.autoApply = false;
-
+  
         if (this.autoApply && typeof options.ranges !== 'object') {
             this.container.find('.ranges').hide();
         } else if (this.autoApply) {
             this.container.find('.applyBtn, .cancelBtn').addClass('hide');
         }
-
+  
         if (this.singleDatePicker) {
             this.container.addClass('single');
             this.container.find('.calendar.left').addClass('single');
@@ -395,11 +395,11 @@
                 this.container.find('.ranges').hide();
             }
         }
-
+  
         if ((typeof options.ranges === 'undefined' && !this.singleDatePicker) || this.alwaysShowCalendars) {
             this.container.addClass('show-calendar');
         }
-        
+  
         if (this.disableInput) {
             var inputStart = this.container.find('.daterangepicker_input input[name=daterangepicker_start]');
             if (inputStart) {
@@ -410,14 +410,14 @@
                 inputEnd.attr('disabled', true);
             }
         }
-
+  
         this.container.addClass('opens' + this.opens);
-
+  
         //swap the position of the predefined ranges if opens right
         if (typeof options.ranges !== 'undefined' && this.opens == 'right') {
             this.container.find('.ranges').prependTo( this.container.find('.calendar.left').parent() );
         }
-
+  
         //apply CSS classes and labels to buttons
         this.container.find('.applyBtn, .cancelBtn').addClass(this.buttonClasses);
         if (this.applyClass.length)
@@ -426,11 +426,11 @@
             this.container.find('.cancelBtn').addClass(this.cancelClass);
         this.container.find('.applyBtn').html(this.locale.applyLabel);
         this.container.find('.cancelBtn').html(this.locale.cancelLabel);
-
+  
         //
         // event listeners
         //
-
+  
         this.container.find('.calendar')
             .on('click.daterangepicker', '.prev', $.proxy(this.clickPrev, this))
             .on('click.daterangepicker', '.next', $.proxy(this.clickNext, this))
@@ -444,14 +444,14 @@
             .on('focus.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsFocused, this))
             .on('blur.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsBlurred, this))
             .on('change.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsChanged, this));
-
+  
         this.container.find('.ranges')
             .on('click.daterangepicker', 'button.applyBtn', $.proxy(this.clickApply, this))
             .on('click.daterangepicker', 'button.cancelBtn', $.proxy(this.clickCancel, this))
             .on('click.daterangepicker', 'li', $.proxy(this.clickRange, this))
             .on('mouseenter.daterangepicker', 'li', $.proxy(this.hoverRange, this))
             .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
-
+  
         if (this.element.is('input') || this.element.is('button')) {
             this.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
@@ -462,11 +462,11 @@
         } else {
             this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
         }
-
+  
         //
         // if attached to a text input, set the initial value
         //
-
+  
         if (this.element.is('input') && !this.singleDatePicker && this.autoUpdateInput) {
             this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
             this.element.trigger('change');
@@ -474,82 +474,82 @@
             this.element.val(this.startDate.format(this.locale.format));
             this.element.trigger('change');
         }
-
+  
     };
-
+  
     DateRangePicker.prototype = {
-
+  
         constructor: DateRangePicker,
-
+  
         setStartDate: function(startDate) {
             if (typeof startDate === 'string')
                 this.startDate = moment(startDate, this.locale.format);
-
+  
             if (typeof startDate === 'object')
                 this.startDate = moment(startDate);
-
+  
             if (!this.timePicker)
                 this.startDate = this.startDate.startOf('day');
-
+  
             if (this.timePicker && this.timePickerIncrement)
                 this.startDate.minute(Math.round(this.startDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
-
+  
             if (this.minDate && this.startDate.isBefore(this.minDate)) {
                 this.startDate = this.minDate.clone();
                 if (this.timePicker && this.timePickerIncrement)
                     this.startDate.minute(Math.round(this.startDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
             }
-
+  
             if (this.maxDate && this.startDate.isAfter(this.maxDate)) {
                 this.startDate = this.maxDate.clone();
                 if (this.timePicker && this.timePickerIncrement)
                     this.startDate.minute(Math.floor(this.startDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
             }
-
+  
             if (!this.isShowing)
                 this.updateElement();
-
+  
             this.updateMonthsInView();
         },
-
+  
         setEndDate: function(endDate) {
             if (typeof endDate === 'string')
                 this.endDate = moment(endDate, this.locale.format);
-
+  
             if (typeof endDate === 'object')
                 this.endDate = moment(endDate);
-
+  
             if (!this.timePicker)
                 this.endDate = this.endDate.endOf('day');
-
+  
             if (this.timePicker && this.timePickerIncrement)
                 this.endDate.minute(Math.round(this.endDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
-
+  
             if (this.endDate.isBefore(this.startDate))
                 this.endDate = this.startDate.clone();
-
+  
             if (this.maxDate && this.endDate.isAfter(this.maxDate))
                 this.endDate = this.maxDate.clone();
-
+  
             if (this.dateLimit && this.startDate.clone().add(this.dateLimit).isBefore(this.endDate))
                 this.endDate = this.startDate.clone().add(this.dateLimit);
-
+  
             this.previousRightTime = this.endDate.clone();
-
+  
             if (!this.isShowing)
                 this.updateElement();
-
+  
             this.updateMonthsInView();
         },
-
+  
         isInvalidDate: function() {
             return false;
         },
-
+  
         isCustomDate: function() {
             return false;
         },
-
+  
         updateView: function() {
             if (this.timePicker) {
                 this.renderTimePicker('left');
@@ -571,10 +571,10 @@
             this.updateCalendars();
             this.updateFormInputs();
         },
-
+  
         updateMonthsInView: function() {
             if (this.endDate) {
-
+  
                 //if both dates are visible already, do nothing
                 if (!this.singleDatePicker && this.leftCalendar.month && this.rightCalendar.month &&
                     (this.startDate.format('YYYY-MM') == this.leftCalendar.month.format('YYYY-MM') || this.startDate.format('YYYY-MM') == this.rightCalendar.month.format('YYYY-MM'))
@@ -583,14 +583,14 @@
                     ) {
                     return;
                 }
-
+  
                 this.leftCalendar.month = this.startDate.clone().date(2);
                 if (!this.linkedCalendars && (this.endDate.month() != this.startDate.month() || this.endDate.year() != this.startDate.year())) {
                     this.rightCalendar.month = this.endDate.clone().date(2);
                 } else {
                     this.rightCalendar.month = this.startDate.clone().date(2).add(1, 'month');
                 }
-
+  
             } else {
                 if (this.leftCalendar.month.format('YYYY-MM') != this.startDate.format('YYYY-MM') && this.rightCalendar.month.format('YYYY-MM') != this.startDate.format('YYYY-MM')) {
                     this.leftCalendar.month = this.startDate.clone().date(2);
@@ -601,10 +601,18 @@
               this.rightCalendar.month = this.maxDate.clone().date(2);
               this.leftCalendar.month = this.maxDate.clone().date(2).subtract(1, 'month');
             }
+  
+            // For non-linked date-range picker, if year-month of startDate, endDate and maxDate are same, then rendering that year-month in rightCalendar and showing previous month in leftCalendar for better UX.
+            if(!this.linkedCalendars && !this.singleDatePicker && this.maxDate && this.startDate && this.endDate
+              && this.startDate.format('YYYY-MM') === this.endDate.format('YYYY-MM') && this.maxDate.format('YYYY-MM') === this.endDate.format('YYYY-MM')) {
+  
+              this.rightCalendar.month = this.maxDate.clone().date(2);
+              this.leftCalendar.month = this.maxDate.clone().date(2).subtract(1, 'month');
+            }
         },
-
+  
         updateCalendars: function() {
-
+  
             if (this.timePicker) {
                 var hour, minute, second;
                 if (this.endDate) {
@@ -633,23 +641,23 @@
                 this.leftCalendar.month.hour(hour).minute(minute).second(second);
                 this.rightCalendar.month.hour(hour).minute(minute).second(second);
             }
-
+  
             this.renderCalendar('left');
             this.renderCalendar('right');
-
+  
             //highlight any predefined range matching the current start and end dates
             this.container.find('.ranges li').removeClass('active');
             if (this.endDate == null) return;
-
+  
             this.calculateChosenLabel();
         },
-
+  
         renderCalendar: function(side) {
-
+  
             //
             // Build the matrix of dates that will populate the calendar
             //
-
+  
             var calendar = side == 'left' ? this.leftCalendar : this.rightCalendar;
             var month = calendar.month.month();
             var year = calendar.month.year();
@@ -663,26 +671,26 @@
             var lastYear = moment(firstDay).subtract(1, 'month').year();
             var daysInLastMonth = moment([lastYear, lastMonth]).daysInMonth();
             var dayOfWeek = firstDay.day();
-
+  
             //initialize a 6 rows x 7 columns array for the calendar
             var calendar = [];
             calendar.firstDay = firstDay;
             calendar.lastDay = lastDay;
-
+  
             for (var i = 0; i < 6; i++) {
                 calendar[i] = [];
             }
-
+  
             //populate the calendar with date objects
             var startDay = daysInLastMonth - dayOfWeek + this.locale.firstDay + 1;
             if (startDay > daysInLastMonth)
                 startDay -= 7;
-
+  
             if (dayOfWeek == this.locale.firstDay)
                 startDay = daysInLastMonth - 6;
-
+  
             var curDate = moment([lastYear, lastMonth, startDay, 12, minute, second]);
-
+  
             var col, row;
             for (var i = 0, col = 0, row = 0; i < 42; i++, col++, curDate = moment(curDate).add(24, 'hour')) {
                 if (i > 0 && col % 7 === 0) {
@@ -691,49 +699,49 @@
                 }
                 calendar[row][col] = curDate.clone().hour(hour).minute(minute).second(second);
                 curDate.hour(12);
-
+  
                 if (this.minDate && calendar[row][col].format('YYYY-MM-DD') == this.minDate.format('YYYY-MM-DD') && calendar[row][col].isBefore(this.minDate) && side == 'left') {
                     calendar[row][col] = this.minDate.clone();
                 }
-
+  
                 if (this.maxDate && calendar[row][col].format('YYYY-MM-DD') == this.maxDate.format('YYYY-MM-DD') && calendar[row][col].isAfter(this.maxDate) && side == 'right') {
                     calendar[row][col] = this.maxDate.clone();
                 }
-
+  
             }
-
+  
             //make the calendar object available to hoverDate/clickDate
             if (side == 'left') {
                 this.leftCalendar.calendar = calendar;
             } else {
                 this.rightCalendar.calendar = calendar;
             }
-
+  
             //
             // Display the calendar
             //
-
+  
             var minDate = side == 'left' ? this.minDate : this.startDate;
             var maxDate = this.maxDate;
             var selected = side == 'left' ? this.startDate : this.endDate;
             var arrow = this.locale.direction == 'ltr' ? {left: 'chevron-left', right: 'chevron-right'} : {left: 'chevron-right', right: 'chevron-left'};
-
+  
             var html = '<table class="table-condensed">';
             html += '<thead>';
             html += '<tr>';
-
+  
             // add empty cell for week number
             if (this.showWeekNumbers || this.showISOWeekNumbers)
                 html += '<th></th>';
-
+  
             if ((!minDate || minDate.isBefore(calendar.firstDay)) && (!this.linkedCalendars || side == 'left')) {
                 html += '<th class="prev available"><i class="fa fa-' + arrow.left + ' glyphicon glyphicon-' + arrow.left + '"></i></th>';
             } else {
                 html += '<th></th>';
             }
-
+  
             var dateHtml = this.locale.monthNames[calendar[1][1].month()] + calendar[1][1].format(" YYYY");
-
+  
             if (this.showDropdowns) {
                 var currentMonth = calendar[1][1].month();
                 var currentYear = calendar[1][1].year();
@@ -741,7 +749,7 @@
                 var minYear = (minDate && minDate.year()) || (currentYear - 50);
                 var inMinYear = currentYear == minYear;
                 var inMaxYear = currentYear == maxYear;
-
+  
                 var monthHtml = '<select class="monthselect">';
                 for (var m = 0; m < 12; m++) {
                     if ((!inMinYear || m >= minDate.month()) && (!inMaxYear || m <= maxDate.month())) {
@@ -755,7 +763,7 @@
                     }
                 }
                 monthHtml += "</select>";
-
+  
                 var yearHtml = '<select class="yearselect">';
                 for (var y = minYear; y <= maxYear; y++) {
                     yearHtml += '<option value="' + y + '"' +
@@ -763,32 +771,32 @@
                         '>' + y + '</option>';
                 }
                 yearHtml += '</select>';
-
+  
                 dateHtml = monthHtml + yearHtml;
             }
-
+  
             html += '<th colspan="5" class="month">' + dateHtml + '</th>';
             if ((!maxDate || maxDate.isAfter(calendar.lastDay)) && (!this.linkedCalendars || side == 'right' || this.singleDatePicker)) {
                 html += '<th class="next available"><i class="fa fa-' + arrow.right + ' glyphicon glyphicon-' + arrow.right + '"></i></th>';
             } else {
                 html += '<th></th>';
             }
-
+  
             html += '</tr>';
             html += '<tr>';
-
+  
             // add week number label
             if (this.showWeekNumbers || this.showISOWeekNumbers)
                 html += '<th class="week">' + this.locale.weekLabel + '</th>';
-
+  
             $.each(this.locale.daysOfWeek, function(index, dayOfWeek) {
                 html += '<th>' + dayOfWeek + '</th>';
             });
-
+  
             html += '</tr>';
             html += '</thead>';
             html += '<tbody>';
-
+  
             //adjust maxDate to reflect the dateLimit setting in order to
             //grey out end dates beyond the dateLimit
             if (this.endDate == null && this.dateLimit) {
@@ -797,56 +805,56 @@
                     maxDate = maxLimit;
                 }
             }
-
+  
             for (var row = 0; row < 6; row++) {
                 html += '<tr>';
-
+  
                 // add week number
                 if (this.showWeekNumbers)
                     html += '<td class="week">' + calendar[row][0].week() + '</td>';
                 else if (this.showISOWeekNumbers)
                     html += '<td class="week">' + calendar[row][0].isoWeek() + '</td>';
-
+  
                 for (var col = 0; col < 7; col++) {
-
+  
                     var classes = [];
-
+  
                     //highlight today's date
                     if (calendar[row][col].isSame(new Date(), "day"))
                         classes.push('today');
-
+  
                     //highlight weekends
                     if (calendar[row][col].isoWeekday() > 5)
                         classes.push('weekend');
-
+  
                     //grey out the dates in other months displayed at beginning and end of this calendar
                     if (calendar[row][col].month() != calendar[1][1].month())
                         classes.push('off');
-
+  
                     //don't allow selection of dates before the minimum date
                     if (this.minDate && calendar[row][col].isBefore(this.minDate, 'day'))
                         classes.push('off', 'disabled');
-
+  
                     //don't allow selection of dates after the maximum date
                     if (maxDate && calendar[row][col].isAfter(maxDate, 'day'))
                         classes.push('off', 'disabled');
-
+  
                     //don't allow selection of date if a custom function decides it's invalid
                     if (this.isInvalidDate(calendar[row][col]))
                         classes.push('off', 'disabled');
-
+  
                     //highlight the currently selected start date
                     if (calendar[row][col].format('YYYY-MM-DD') == this.startDate.format('YYYY-MM-DD'))
                         classes.push('active', 'start-date');
-
+  
                     //highlight the currently selected end date
                     if (this.endDate != null && calendar[row][col].format('YYYY-MM-DD') == this.endDate.format('YYYY-MM-DD'))
                         classes.push('active', 'end-date');
-
+  
                     //highlight dates in-between the selected dates
                     if (this.endDate != null && calendar[row][col] > this.startDate && calendar[row][col] < this.endDate)
                         classes.push('in-range');
-
+  
                     //apply custom classes for this date
                     var isCustom = this.isCustomDate(calendar[row][col]);
                     if (isCustom !== false) {
@@ -855,7 +863,7 @@
                         else
                             Array.prototype.push.apply(classes, isCustom);
                     }
-
+  
                     var cname = '', disabled = false;
                     for (var i = 0; i < classes.length; i++) {
                         cname += classes[i] + ' ';
@@ -864,46 +872,46 @@
                     }
                     if (!disabled)
                         cname += 'available';
-
+  
                     html += '<td class="' + cname.replace(/^\s+|\s+$/g, '') + '" data-title="' + 'r' + row + 'c' + col + '">' + calendar[row][col].date() + '</td>';
-
+  
                 }
                 html += '</tr>';
             }
-
+  
             html += '</tbody>';
             html += '</table>';
-
+  
             this.container.find('.calendar.' + side + ' .calendar-table').html(html);
-
+  
         },
-
+  
         renderTimePicker: function(side) {
-
+  
             // Don't bother updating the time picker if it's currently disabled
             // because an end date hasn't been clicked yet
             if (side == 'right' && !this.endDate) return;
-
+  
             var html, selected, minDate, maxDate = this.maxDate;
-
+  
             if (this.dateLimit && (!this.maxDate || this.startDate.clone().add(this.dateLimit).isAfter(this.maxDate)))
                 maxDate = this.startDate.clone().add(this.dateLimit);
-
+  
             if (side == 'left') {
                 selected = this.startDate.clone();
                 minDate = this.minDate;
             } else if (side == 'right') {
                 selected = this.endDate.clone();
                 minDate = this.startDate;
-
+  
                 //Preserve the time already selected
                 var timeSelector = this.container.find('.calendar.right .calendar-time div');
                 if (timeSelector.html() != '') {
-
+  
                     selected.hour(timeSelector.find('.hourselect option:selected').val() || selected.hour());
                     selected.minute(timeSelector.find('.minuteselect option:selected').val() || selected.minute());
                     selected.second(timeSelector.find('.secondselect option:selected').val() || selected.second());
-
+  
                     if (!this.timePicker24Hour) {
                         var ampm = timeSelector.find('.ampmselect option:selected').val();
                         if (ampm === 'PM' && selected.hour() < 12)
@@ -911,38 +919,38 @@
                         if (ampm === 'AM' && selected.hour() === 12)
                             selected.hour(0);
                     }
-
+  
                 }
-
+  
                 if (selected.isBefore(this.startDate))
                     selected = this.startDate.clone();
-
+  
                 if (maxDate && selected.isAfter(maxDate))
                     selected = maxDate.clone();
-
+  
             }
-
+  
             //
             // hours
             //
-
+  
             html = '<select class="hourselect">';
-
+  
             var start = this.timePicker24Hour ? 0 : 1;
             var end = this.timePicker24Hour ? 23 : 12;
-
+  
             for (var i = start; i <= end; i++) {
                 var i_in_24 = i;
                 if (!this.timePicker24Hour)
                     i_in_24 = selected.hour() >= 12 ? (i == 12 ? 12 : i + 12) : (i == 12 ? 0 : i);
-
+  
                 var time = selected.clone().hour(i_in_24);
                 var disabled = false;
                 if (minDate && time.minute(59).isBefore(minDate))
                     disabled = true;
                 if (maxDate && time.minute(0).isAfter(maxDate))
                     disabled = true;
-
+  
                 if (i_in_24 == selected.hour() && !disabled) {
                     html += '<option value="' + i + '" selected="selected">' + i + '</option>';
                 } else if (disabled) {
@@ -951,25 +959,25 @@
                     html += '<option value="' + i + '">' + i + '</option>';
                 }
             }
-
+  
             html += '</select> ';
-
+  
             //
             // minutes
             //
-
+  
             html += ': <select class="minuteselect">';
-
+  
             for (var i = 0; i < 60; i += this.timePickerIncrement) {
                 var padded = i < 10 ? '0' + i : i;
                 var time = selected.clone().minute(i);
-
+  
                 var disabled = false;
                 if (minDate && time.second(59).isBefore(minDate))
                     disabled = true;
                 if (maxDate && time.second(0).isAfter(maxDate))
                     disabled = true;
-
+  
                 if (selected.minute() == i && !disabled) {
                     html += '<option value="' + i + '" selected="selected">' + padded + '</option>';
                 } else if (disabled) {
@@ -978,26 +986,26 @@
                     html += '<option value="' + i + '">' + padded + '</option>';
                 }
             }
-
+  
             html += '</select> ';
-
+  
             //
             // seconds
             //
-
+  
             if (this.timePickerSeconds) {
                 html += ': <select class="secondselect">';
-
+  
                 for (var i = 0; i < 60; i++) {
                     var padded = i < 10 ? '0' + i : i;
                     var time = selected.clone().second(i);
-
+  
                     var disabled = false;
                     if (minDate && time.isBefore(minDate))
                         disabled = true;
                     if (maxDate && time.isAfter(maxDate))
                         disabled = true;
-
+  
                     if (selected.second() == i && !disabled) {
                         html += '<option value="' + i + '" selected="selected">' + padded + '</option>';
                     } else if (disabled) {
@@ -1006,57 +1014,57 @@
                         html += '<option value="' + i + '">' + padded + '</option>';
                     }
                 }
-
+  
                 html += '</select> ';
             }
-
+  
             //
             // AM/PM
             //
-
+  
             if (!this.timePicker24Hour) {
                 html += '<select class="ampmselect">';
-
+  
                 var am_html = '';
                 var pm_html = '';
-
+  
                 if (minDate && selected.clone().hour(12).minute(0).second(0).isBefore(minDate))
                     am_html = ' disabled="disabled" class="disabled"';
-
+  
                 if (maxDate && selected.clone().hour(0).minute(0).second(0).isAfter(maxDate))
                     pm_html = ' disabled="disabled" class="disabled"';
-
+  
                 if (selected.hour() >= 12) {
                     html += '<option value="AM"' + am_html + '>AM</option><option value="PM" selected="selected"' + pm_html + '>PM</option>';
                 } else {
                     html += '<option value="AM" selected="selected"' + am_html + '>AM</option><option value="PM"' + pm_html + '>PM</option>';
                 }
-
+  
                 html += '</select>';
             }
-
+  
             this.container.find('.calendar.' + side + ' .calendar-time div').html(html);
-
+  
         },
-
+  
         updateFormInputs: function() {
-
+  
             //ignore mouse movements while an above-calendar text input has focus
             if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
                 return;
-
+  
             this.container.find('input[name=daterangepicker_start]').val(this.startDate.format(this.locale.format));
             if (this.endDate)
                 this.container.find('input[name=daterangepicker_end]').val(this.endDate.format(this.locale.format));
-
+  
             if (this.singleDatePicker || (this.endDate && (this.startDate.isBefore(this.endDate) || this.startDate.isSame(this.endDate)))) {
                 this.container.find('button.applyBtn').removeAttr('disabled');
             } else {
                 this.container.find('button.applyBtn').attr('disabled', 'disabled');
             }
-
+  
         },
-
+  
         move: function() {
             var parentOffset = { top: 0, left: 0 },
                 containerTop;
@@ -1068,13 +1076,13 @@
                 };
                 parentRightEdge = this.parentEl[0].clientWidth + this.parentEl.offset().left;
             }
-
+  
             if (this.drops == 'up')
                 containerTop = this.element.offset().top - this.container.outerHeight() - parentOffset.top;
             else
                 containerTop = this.element.offset().top + this.element.outerHeight() - parentOffset.top;
             this.container[this.drops == 'up' ? 'addClass' : 'removeClass']('dropup');
-
+  
             if (this.opens == 'left') {
                 this.container.css({
                     top: containerTop,
@@ -1114,13 +1122,13 @@
                 }
             }
         },
-
+  
         show: function(e) {
             if (this.isShowing) return;
-
+  
             // Create a click proxy that is private to this instance of datepicker, for unbinding
             this._outsideClickProxy = $.proxy(function(e) { this.outsideClick(e); }, this);
-
+  
             // Bind global datepicker mousedown for hiding and
             $(document)
               .on('mousedown.daterangepicker', this._outsideClickProxy)
@@ -1130,44 +1138,44 @@
               .on('click.daterangepicker', '[data-toggle=dropdown]', this._outsideClickProxy)
               // and also close when focus changes to outside the picker (eg. tabbing between controls)
               .on('focusin.daterangepicker', this._outsideClickProxy);
-
+  
             // Reposition the picker if the window is resized while it's open
             $(window).on('resize.daterangepicker', $.proxy(function(e) { this.move(e); }, this));
-
+  
             this.oldStartDate = this.startDate.clone();
             this.oldEndDate = this.endDate.clone();
             this.previousRightTime = this.endDate.clone();
-
+  
             this.updateView();
             this.container.show();
             this.move();
             this.element.trigger('show.daterangepicker', this);
             this.isShowing = true;
         },
-
+  
         hide: function(e) {
             if (!this.isShowing) return;
-
+  
             //incomplete date selection, revert to last values
             if (!this.endDate) {
                 this.startDate = this.oldStartDate.clone();
                 this.endDate = this.oldEndDate.clone();
             }
-
+  
             //if a new date range was selected, invoke the user callback function
             if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate) || this.emitChangeOnSameDate)
                 this.callback(this.startDate, this.endDate, this.chosenLabel);
-
+  
             //if picker is attached to a text input, update it
             this.updateElement();
-
+  
             $(document).off('.daterangepicker');
             $(window).off('.daterangepicker');
             this.container.hide();
             this.element.trigger('hide.daterangepicker', this);
             this.isShowing = false;
         },
-
+  
         toggle: function(e) {
             if (this.isShowing) {
                 this.hide();
@@ -1175,7 +1183,7 @@
                 this.show();
             }
         },
-
+  
         outsideClick: function(e) {
             var target = $(e.target);
             // if the page is clicked anywhere except within the daterangerpicker/button
@@ -1190,26 +1198,26 @@
             this.hide();
             this.element.trigger('outsideClick.daterangepicker', this);
         },
-
+  
         showCalendars: function() {
             this.container.addClass('show-calendar');
             this.move();
             this.element.trigger('showCalendar.daterangepicker', this);
         },
-
+  
         hideCalendars: function() {
             this.container.removeClass('show-calendar');
             this.element.trigger('hideCalendar.daterangepicker', this);
         },
-
+  
         hoverRange: function(e) {
-
+  
             //ignore mouse movements while an above-calendar text input has focus
             if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
                 return;
-
+  
             var label = e.target.getAttribute('data-range-key');
-
+  
             if (label == this.locale.customRangeLabel) {
                 this.updateView();
             } else {
@@ -1217,9 +1225,9 @@
                 this.container.find('input[name=daterangepicker_start]').val(dates[0].format(this.locale.format));
                 this.container.find('input[name=daterangepicker_end]').val(dates[1].format(this.locale.format));
             }
-
+  
         },
-
+  
         clickRange: function(e) {
             var label = e.target.getAttribute('data-range-key');
             this.chosenLabel = label;
@@ -1229,18 +1237,18 @@
                 var dates = this.ranges[label];
                 this.startDate = dates[0];
                 this.endDate = dates[1];
-
+  
                 if (!this.timePicker) {
                     this.startDate.startOf('day');
                     this.endDate.endOf('day');
                 }
-
+  
                 if (!this.alwaysShowCalendars)
                     this.hideCalendars();
                 this.clickApply();
             }
         },
-
+  
         clickPrev: function(e) {
             var cal = $(e.target).parents('.calendar');
             if (cal.hasClass('left')) {
@@ -1252,7 +1260,7 @@
             }
             this.updateCalendars();
         },
-
+  
         clickNext: function(e) {
             var cal = $(e.target).parents('.calendar');
             if (cal.hasClass('left')) {
@@ -1264,66 +1272,66 @@
             }
             this.updateCalendars();
         },
-
+  
         hoverDate: function(e) {
-
+  
             //ignore mouse movements while an above-calendar text input has focus
             //if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
             //    return;
-
+  
             //ignore dates that can't be selected
             if (!$(e.target).hasClass('available')) return;
-
+  
             //have the text inputs above calendars reflect the date being hovered over
             var title = $(e.target).attr('data-title');
             var row = title.substr(1, 1);
             var col = title.substr(3, 1);
             var cal = $(e.target).parents('.calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
-
+  
             if (this.endDate && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
                 this.container.find('input[name=daterangepicker_start]').val(date.format(this.locale.format));
             } else if (!this.endDate && !this.container.find('input[name=daterangepicker_end]').is(":focus")) {
                 this.container.find('input[name=daterangepicker_end]').val(date.format(this.locale.format));
             }
-
+  
             //highlight the dates between the start date and the date being hovered as a potential end date
             var leftCalendar = this.leftCalendar;
             var rightCalendar = this.rightCalendar;
             var startDate = this.startDate;
             if (!this.endDate) {
                 this.container.find('.calendar tbody td').each(function(index, el) {
-
+  
                     //skip week numbers, only look at dates
                     if ($(el).hasClass('week')) return;
-
+  
                     var title = $(el).attr('data-title');
                     var row = title.substr(1, 1);
                     var col = title.substr(3, 1);
                     var cal = $(el).parents('.calendar');
                     var dt = cal.hasClass('left') ? leftCalendar.calendar[row][col] : rightCalendar.calendar[row][col];
-
+  
                     if ((dt.isAfter(startDate) && dt.isBefore(date)) || dt.isSame(date, 'day')) {
                         $(el).addClass('in-range');
                     } else {
                         $(el).removeClass('in-range');
                     }
-
+  
                 });
             }
-
+  
         },
-
+  
         clickDate: function(e) {
-
+  
             if (!$(e.target).hasClass('available')) return;
-
+  
             var title = $(e.target).attr('data-title');
             var row = title.substr(1, 1);
             var col = title.substr(3, 1);
             var cal = $(e.target).parents('.calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
-
+  
             //
             // this function needs to do a few things:
             // * alternate between selecting a start and end date for the range,
@@ -1332,7 +1340,7 @@
             // * if single date picker mode, and time picker isn't enabled, apply the selection immediately
             // * if one of the inputs above the calendars was focused, cancel that manual input
             //
-
+  
             if (this.endDate || date.isBefore(this.startDate, 'day')) { //picking start
                 if (this.timePicker) {
                     var hour = parseInt(this.container.find('.left .hourselect').val(), 10);
@@ -1373,20 +1381,20 @@
                   this.clickApply();
                 }
             }
-
+  
             if (this.singleDatePicker) {
                 this.setEndDate(this.startDate);
                 if (!this.timePicker)
                     this.clickApply();
             }
-
+  
             this.updateView();
-
+  
             //This is to cancel the blur event handler if the mouse was in one of the inputs
             e.stopPropagation();
-
+  
         },
-
+  
         calculateChosenLabel: function () {
             var customRange = true;
             var i = 0;
@@ -1416,49 +1424,49 @@
                 this.showCalendars();
             }
         },
-
+  
         clickApply: function(e) {
             this.hide();
             this.element.trigger('apply.daterangepicker', this);
         },
-
+  
         clickCancel: function(e) {
             this.startDate = this.oldStartDate;
             this.endDate = this.oldEndDate;
             this.hide();
             this.element.trigger('cancel.daterangepicker', this);
         },
-
+  
         monthOrYearChanged: function(e) {
             var isLeft = $(e.target).closest('.calendar').hasClass('left'),
                 leftOrRight = isLeft ? 'left' : 'right',
                 cal = this.container.find('.calendar.'+leftOrRight);
-
+  
             // Month must be Number for new moment versions
             var month = parseInt(cal.find('.monthselect').val(), 10);
             var year = cal.find('.yearselect').val();
-
+  
             if (!isLeft) {
                 if (year < this.startDate.year() || (year == this.startDate.year() && month < this.startDate.month())) {
                     month = this.startDate.month();
                     year = this.startDate.year();
                 }
             }
-
+  
             if (this.minDate) {
                 if (year < this.minDate.year() || (year == this.minDate.year() && month < this.minDate.month())) {
                     month = this.minDate.month();
                     year = this.minDate.year();
                 }
             }
-
+  
             if (this.maxDate) {
                 if (year > this.maxDate.year() || (year == this.maxDate.year() && month > this.maxDate.month())) {
                     month = this.maxDate.month();
                     year = this.maxDate.year();
                 }
             }
-
+  
             if (isLeft) {
                 this.leftCalendar.month.month(month).year(year);
                 if (this.linkedCalendars)
@@ -1470,16 +1478,16 @@
             }
             this.updateCalendars();
         },
-
+  
         timeChanged: function(e) {
-
+  
             var cal = $(e.target).closest('.calendar'),
                 isLeft = cal.hasClass('left');
-
+  
             var hour = parseInt(cal.find('.hourselect').val(), 10);
             var minute = parseInt(cal.find('.minuteselect').val(), 10);
             var second = this.timePickerSeconds ? parseInt(cal.find('.secondselect').val(), 10) : 0;
-
+  
             if (!this.timePicker24Hour) {
                 var ampm = cal.find('.ampmselect').val();
                 if (ampm === 'PM' && hour < 12)
@@ -1487,7 +1495,7 @@
                 if (ampm === 'AM' && hour === 12)
                     hour = 0;
             }
-
+  
             if (isLeft) {
                 var start = this.startDate.clone();
                 start.hour(hour);
@@ -1506,50 +1514,50 @@
                 end.second(second);
                 this.setEndDate(end);
             }
-
+  
             //update the calendars so all clickable dates reflect the new time component
             this.updateCalendars();
-
+  
             //update the form inputs above the calendars with the new time
             this.updateFormInputs();
-
+  
             //re-render the time pickers because changing one selection can affect what's enabled in another
             this.renderTimePicker('left');
             this.renderTimePicker('right');
-
+  
         },
-
+  
         formInputsChanged: function(e) {
             var isRight = $(e.target).closest('.calendar').hasClass('right');
             var start = moment(this.container.find('input[name="daterangepicker_start"]').val(), this.locale.format);
             var end = moment(this.container.find('input[name="daterangepicker_end"]').val(), this.locale.format);
-
+  
             if (start.isValid() && end.isValid()) {
-
+  
                 if (isRight && end.isBefore(start))
                     start = end.clone();
-
+  
                 this.setStartDate(start);
                 this.setEndDate(end);
-
+  
                 if (isRight) {
                     this.container.find('input[name="daterangepicker_start"]').val(this.startDate.format(this.locale.format));
                 } else {
                     this.container.find('input[name="daterangepicker_end"]').val(this.endDate.format(this.locale.format));
                 }
-
+  
             }
-
+  
             this.updateView();
         },
-
+  
         formInputsFocused: function(e) {
-
+  
             // Highlight the focused input
             this.container.find('input[name="daterangepicker_start"], input[name="daterangepicker_end"]').removeClass('active');
             $(e.target).addClass('active');
-
-            // Set the state such that if the user goes back to using a mouse, 
+  
+            // Set the state such that if the user goes back to using a mouse,
             // the calendars are aware we're selecting the end of the range, not
             // the start. This allows someone to edit the end of a date range without
             // re-selecting the beginning, by clicking on the end date input then
@@ -1560,16 +1568,16 @@
                 this.setStartDate(this.startDate.clone());
                 this.updateView();
             }
-
+  
         },
-
+  
         formInputsBlurred: function(e) {
-
+  
             // this function has one purpose right now: if you tab from the first
             // text input to the second in the UI, the endDate is nulled so that
             // you can click another, but if you tab out without clicking anything
             // or changing the input value, the old endDate should be retained
-
+  
             if (!this.endDate) {
                 var val = this.container.find('input[name="daterangepicker_end"]').val();
                 var end = moment(val, this.locale.format);
@@ -1578,42 +1586,42 @@
                     this.updateView();
                 }
             }
-
+  
         },
-
+  
         elementChanged: function() {
             if (!this.element.is('input')) return;
             if (!this.element.val().length) return;
             if (this.element.val().length < this.locale.format.length) return;
-
+  
             var dateString = this.element.val().split(this.locale.separator),
                 start = null,
                 end = null;
-
+  
             if (dateString.length === 2) {
                 start = moment(dateString[0], this.locale.format);
                 end = moment(dateString[1], this.locale.format);
             }
-
+  
             if (this.singleDatePicker || start === null || end === null) {
                 start = moment(this.element.val(), this.locale.format);
                 end = start;
             }
-
+  
             if (!start.isValid() || !end.isValid()) return;
-
+  
             this.setStartDate(start);
             this.setEndDate(end);
             this.updateView();
         },
-
+  
         keydown: function(e) {
             //hide on tab or enter
             if ((e.keyCode === 9) || (e.keyCode === 13)) {
                 this.hide();
             }
         },
-
+  
         updateElement: function() {
             if (this.element.is('input') && !this.singleDatePicker && this.autoUpdateInput) {
                 this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
@@ -1623,15 +1631,15 @@
                 this.element.trigger('change');
             }
         },
-
+  
         remove: function() {
             this.container.remove();
             this.element.off('.daterangepicker');
             this.element.removeData();
         }
-
+  
     };
-
+  
     $.fn.daterangepicker = function(options, callback) {
         this.each(function() {
             var el = $(this);
@@ -1641,7 +1649,8 @@
         });
         return this;
     };
-
+  
     return DateRangePicker;
-
-}));
+  
+  }));
+  

--- a/daterangepicker.js
+++ b/daterangepicker.js
@@ -27,9 +27,9 @@
         // Browser globals
         root.daterangepicker = factory(root.moment, root.jQuery);
     }
-  }(this, function(moment, $) {
+}(this, function(moment, $) {
     var DateRangePicker = function(element, options, cb) {
-  
+
         //default settings for options
         this.parentEl = 'body';
         this.element = $(element);
@@ -54,19 +54,19 @@
         this.disableInput = false;
         this.emitChangeOnSameDate = false;
         this.ranges = {};
-  
+
         this.opens = 'right';
         if (this.element.hasClass('pull-right'))
             this.opens = 'left';
-  
+
         this.drops = 'down';
         if (this.element.hasClass('dropup'))
             this.drops = 'up';
-  
+
         this.buttonClasses = 'btn btn-sm';
         this.applyClass = 'btn-success';
         this.cancelClass = 'btn-default';
-  
+
         this.locale = {
             direction: 'ltr',
             format: moment.localeData().longDateFormat('L'),
@@ -79,22 +79,22 @@
             monthNames: moment.monthsShort(),
             firstDay: moment.localeData().firstDayOfWeek()
         };
-  
+
         this.callback = function() { };
-  
+
         //some state information
         this.isShowing = false;
         this.leftCalendar = {};
         this.rightCalendar = {};
-  
+
         //custom options from user
         if (typeof options !== 'object' || options === null)
             options = {};
-  
+
         //allow setting options with data attributes
         //data-api options will be overwritten with custom javascript options
         options = $.extend(this.element.data(), options);
-  
+
         //html template for the picker UI
         if (typeof options.template !== 'string' && !(options.template instanceof $))
             options.template = '<div class="daterangepicker dropdown-menu">' +
@@ -127,43 +127,43 @@
                     '</div>' +
                 '</div>' +
             '</div>';
-  
+
         this.parentEl = (options.parentEl && $(options.parentEl).length) ? $(options.parentEl) : $(this.parentEl);
         this.container = $(options.template).appendTo(this.parentEl);
-  
+
         //
         // handle all the possible options overriding defaults
         //
-  
+
         if (typeof options.locale === 'object') {
-  
+
             if (typeof options.locale.direction === 'string')
                 this.locale.direction = options.locale.direction;
-  
+
             if (typeof options.locale.format === 'string')
                 this.locale.format = options.locale.format;
-  
+
             if (typeof options.locale.separator === 'string')
                 this.locale.separator = options.locale.separator;
-  
+
             if (typeof options.locale.daysOfWeek === 'object')
                 this.locale.daysOfWeek = options.locale.daysOfWeek.slice();
-  
+
             if (typeof options.locale.monthNames === 'object')
               this.locale.monthNames = options.locale.monthNames.slice();
-  
+
             if (typeof options.locale.firstDay === 'number')
               this.locale.firstDay = options.locale.firstDay;
-  
+
             if (typeof options.locale.applyLabel === 'string')
               this.locale.applyLabel = options.locale.applyLabel;
-  
+
             if (typeof options.locale.cancelLabel === 'string')
               this.locale.cancelLabel = options.locale.cancelLabel;
-  
+
             if (typeof options.locale.weekLabel === 'string')
               this.locale.weekLabel = options.locale.weekLabel;
-  
+
             if (typeof options.locale.customRangeLabel === 'string'){
                 //Support unicode chars in the custom range name.
                 var elem = document.createElement('textarea');
@@ -173,114 +173,114 @@
             }
         }
         this.container.addClass(this.locale.direction);
-  
+
         if (typeof options.startDate === 'string')
             this.startDate = moment(options.startDate, this.locale.format);
-  
+
         if (typeof options.endDate === 'string')
             this.endDate = moment(options.endDate, this.locale.format);
-  
+
         if (typeof options.minDate === 'string')
             this.minDate = moment(options.minDate, this.locale.format);
-  
+
         if (typeof options.maxDate === 'string')
             this.maxDate = moment(options.maxDate, this.locale.format);
-  
+
         if (typeof options.startDate === 'object')
             this.startDate = moment(options.startDate);
-  
+
         if (typeof options.endDate === 'object')
             this.endDate = moment(options.endDate);
-  
+
         if (typeof options.minDate === 'object')
             this.minDate = moment(options.minDate);
-  
+
         if (typeof options.maxDate === 'object')
             this.maxDate = moment(options.maxDate);
-  
+
         // sanity check for bad options
         if (this.minDate && this.startDate.isBefore(this.minDate))
             this.startDate = this.minDate.clone();
-  
+
         // sanity check for bad options
         if (this.maxDate && this.endDate.isAfter(this.maxDate))
             this.endDate = this.maxDate.clone();
-  
+
         if (typeof options.applyClass === 'string')
             this.applyClass = options.applyClass;
-  
+
         if (typeof options.cancelClass === 'string')
             this.cancelClass = options.cancelClass;
-  
+
         if (typeof options.dateLimit === 'object')
             this.dateLimit = options.dateLimit;
-  
+
         if (typeof options.opens === 'string')
             this.opens = options.opens;
-  
+
         if (typeof options.drops === 'string')
             this.drops = options.drops;
-  
+
         if (typeof options.showWeekNumbers === 'boolean')
             this.showWeekNumbers = options.showWeekNumbers;
-  
+
         if (typeof options.showISOWeekNumbers === 'boolean')
             this.showISOWeekNumbers = options.showISOWeekNumbers;
-  
+
         if (typeof options.buttonClasses === 'string')
             this.buttonClasses = options.buttonClasses;
-  
+
         if (typeof options.buttonClasses === 'object')
             this.buttonClasses = options.buttonClasses.join(' ');
-  
+
         if (typeof options.showDropdowns === 'boolean')
             this.showDropdowns = options.showDropdowns;
-  
+
         if (typeof options.showCustomRangeLabel === 'boolean')
             this.showCustomRangeLabel = options.showCustomRangeLabel;
-  
+
         if (typeof options.singleDatePicker === 'boolean') {
             this.singleDatePicker = options.singleDatePicker;
             if (this.singleDatePicker)
                 this.endDate = this.startDate.clone();
         }
-  
+
         if (typeof options.timePicker === 'boolean')
             this.timePicker = options.timePicker;
-  
+
         if (typeof options.timePickerSeconds === 'boolean')
             this.timePickerSeconds = options.timePickerSeconds;
-  
+
         if (typeof options.timePickerIncrement === 'number')
             this.timePickerIncrement = options.timePickerIncrement;
-  
+
         if (typeof options.timePicker24Hour === 'boolean')
             this.timePicker24Hour = options.timePicker24Hour;
-  
+
         if (typeof options.autoApply === 'boolean')
             this.autoApply = options.autoApply;
-  
+
         if (typeof options.autoUpdateInput === 'boolean')
             this.autoUpdateInput = options.autoUpdateInput;
-  
+
         if (typeof options.disableInput === 'boolean')
             this.disableInput = options.disableInput;
-  
+
         if (typeof options.emitChangeOnSameDate === 'boolean')
             this.emitChangeOnSameDate = options.emitChangeOnSameDate;
-  
+
         if (typeof options.linkedCalendars === 'boolean')
             this.linkedCalendars = options.linkedCalendars;
-  
+
         if (typeof options.isInvalidDate === 'function')
             this.isInvalidDate = options.isInvalidDate;
-  
+
         if (typeof options.isCustomDate === 'function')
             this.isCustomDate = options.isCustomDate;
-  
+
         if (typeof options.alwaysShowCalendars === 'boolean')
             this.alwaysShowCalendars = options.alwaysShowCalendars;
-  
+
         // update day names order to firstDay
         if (this.locale.firstDay != 0) {
             var iterator = this.locale.firstDay;
@@ -289,17 +289,17 @@
                 iterator--;
             }
         }
-  
+
         var start, end, range;
-  
+
         //if no start/end dates set, check if an input element contains initial values
         if (typeof options.startDate === 'undefined' && typeof options.endDate === 'undefined') {
             if ($(this.element).is('input[type=text]')) {
                 var val = $(this.element).val(),
                     split = val.split(this.locale.separator);
-  
+
                 start = end = null;
-  
+
                 if (split.length == 2) {
                     start = moment(split[0], this.locale.format);
                     end = moment(split[1], this.locale.format);
@@ -313,45 +313,45 @@
                 }
             }
         }
-  
+
         if (typeof options.ranges === 'object') {
             for (range in options.ranges) {
-  
+
                 if (typeof options.ranges[range][0] === 'string')
                     start = moment(options.ranges[range][0], this.locale.format);
                 else
                     start = moment(options.ranges[range][0]);
-  
+
                 if (typeof options.ranges[range][1] === 'string')
                     end = moment(options.ranges[range][1], this.locale.format);
                 else
                     end = moment(options.ranges[range][1]);
-  
+
                 // If the start or end date exceed those allowed by the minDate or dateLimit
                 // options, shorten the range to the allowable period.
                 if (this.minDate && start.isBefore(this.minDate))
                     start = this.minDate.clone();
-  
+
                 var maxDate = this.maxDate;
                 if (this.dateLimit && maxDate && start.clone().add(this.dateLimit).isAfter(maxDate))
                     maxDate = start.clone().add(this.dateLimit);
                 if (maxDate && end.isAfter(maxDate))
                     end = maxDate.clone();
-  
+
                 // If the end of the range is before the minimum or the start of the range is
                 // after the maximum, don't display this range option at all.
-                if ((this.minDate && end.isBefore(this.minDate, this.timepicker ? 'minute' : 'day'))
+                if ((this.minDate && end.isBefore(this.minDate, this.timepicker ? 'minute' : 'day')) 
                   || (maxDate && start.isAfter(maxDate, this.timepicker ? 'minute' : 'day')))
                     continue;
-  
+
                 //Support unicode chars in the range names.
                 var elem = document.createElement('textarea');
                 elem.innerHTML = range;
                 var rangeHtml = elem.value;
-  
+
                 this.ranges[rangeHtml] = [start, end];
             }
-  
+
             var list = '<ul>';
             for (range in this.ranges) {
                 list += '<li data-range-key="' + range + '">' + range + '</li>';
@@ -362,27 +362,27 @@
             list += '</ul>';
             this.container.find('.ranges').prepend(list);
         }
-  
+
         if (typeof cb === 'function') {
             this.callback = cb;
         }
-  
+
         if (!this.timePicker) {
             this.startDate = this.startDate.startOf('day');
             this.endDate = this.endDate.endOf('day');
             this.container.find('.calendar-time').hide();
         }
-  
+
         //can't be used together for now
         if (this.timePicker && this.autoApply)
             this.autoApply = false;
-  
+
         if (this.autoApply && typeof options.ranges !== 'object') {
             this.container.find('.ranges').hide();
         } else if (this.autoApply) {
             this.container.find('.applyBtn, .cancelBtn').addClass('hide');
         }
-  
+
         if (this.singleDatePicker) {
             this.container.addClass('single');
             this.container.find('.calendar.left').addClass('single');
@@ -395,11 +395,11 @@
                 this.container.find('.ranges').hide();
             }
         }
-  
+
         if ((typeof options.ranges === 'undefined' && !this.singleDatePicker) || this.alwaysShowCalendars) {
             this.container.addClass('show-calendar');
         }
-  
+        
         if (this.disableInput) {
             var inputStart = this.container.find('.daterangepicker_input input[name=daterangepicker_start]');
             if (inputStart) {
@@ -410,14 +410,14 @@
                 inputEnd.attr('disabled', true);
             }
         }
-  
+
         this.container.addClass('opens' + this.opens);
-  
+
         //swap the position of the predefined ranges if opens right
         if (typeof options.ranges !== 'undefined' && this.opens == 'right') {
             this.container.find('.ranges').prependTo( this.container.find('.calendar.left').parent() );
         }
-  
+
         //apply CSS classes and labels to buttons
         this.container.find('.applyBtn, .cancelBtn').addClass(this.buttonClasses);
         if (this.applyClass.length)
@@ -426,11 +426,11 @@
             this.container.find('.cancelBtn').addClass(this.cancelClass);
         this.container.find('.applyBtn').html(this.locale.applyLabel);
         this.container.find('.cancelBtn').html(this.locale.cancelLabel);
-  
+
         //
         // event listeners
         //
-  
+
         this.container.find('.calendar')
             .on('click.daterangepicker', '.prev', $.proxy(this.clickPrev, this))
             .on('click.daterangepicker', '.next', $.proxy(this.clickNext, this))
@@ -444,14 +444,14 @@
             .on('focus.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsFocused, this))
             .on('blur.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsBlurred, this))
             .on('change.daterangepicker', '.daterangepicker_input input', $.proxy(this.formInputsChanged, this));
-  
+
         this.container.find('.ranges')
             .on('click.daterangepicker', 'button.applyBtn', $.proxy(this.clickApply, this))
             .on('click.daterangepicker', 'button.cancelBtn', $.proxy(this.clickCancel, this))
             .on('click.daterangepicker', 'li', $.proxy(this.clickRange, this))
             .on('mouseenter.daterangepicker', 'li', $.proxy(this.hoverRange, this))
             .on('mouseleave.daterangepicker', 'li', $.proxy(this.updateFormInputs, this));
-  
+
         if (this.element.is('input') || this.element.is('button')) {
             this.element.on({
                 'click.daterangepicker': $.proxy(this.show, this),
@@ -462,11 +462,11 @@
         } else {
             this.element.on('click.daterangepicker', $.proxy(this.toggle, this));
         }
-  
+
         //
         // if attached to a text input, set the initial value
         //
-  
+
         if (this.element.is('input') && !this.singleDatePicker && this.autoUpdateInput) {
             this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
             this.element.trigger('change');
@@ -474,82 +474,82 @@
             this.element.val(this.startDate.format(this.locale.format));
             this.element.trigger('change');
         }
-  
+
     };
-  
+
     DateRangePicker.prototype = {
-  
+
         constructor: DateRangePicker,
-  
+
         setStartDate: function(startDate) {
             if (typeof startDate === 'string')
                 this.startDate = moment(startDate, this.locale.format);
-  
+
             if (typeof startDate === 'object')
                 this.startDate = moment(startDate);
-  
+
             if (!this.timePicker)
                 this.startDate = this.startDate.startOf('day');
-  
+
             if (this.timePicker && this.timePickerIncrement)
                 this.startDate.minute(Math.round(this.startDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
-  
+
             if (this.minDate && this.startDate.isBefore(this.minDate)) {
                 this.startDate = this.minDate.clone();
                 if (this.timePicker && this.timePickerIncrement)
                     this.startDate.minute(Math.round(this.startDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
             }
-  
+
             if (this.maxDate && this.startDate.isAfter(this.maxDate)) {
                 this.startDate = this.maxDate.clone();
                 if (this.timePicker && this.timePickerIncrement)
                     this.startDate.minute(Math.floor(this.startDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
             }
-  
+
             if (!this.isShowing)
                 this.updateElement();
-  
+
             this.updateMonthsInView();
         },
-  
+
         setEndDate: function(endDate) {
             if (typeof endDate === 'string')
                 this.endDate = moment(endDate, this.locale.format);
-  
+
             if (typeof endDate === 'object')
                 this.endDate = moment(endDate);
-  
+
             if (!this.timePicker)
                 this.endDate = this.endDate.endOf('day');
-  
+
             if (this.timePicker && this.timePickerIncrement)
                 this.endDate.minute(Math.round(this.endDate.minute() / this.timePickerIncrement) * this.timePickerIncrement);
-  
+
             if (this.endDate.isBefore(this.startDate))
                 this.endDate = this.startDate.clone();
-  
+
             if (this.maxDate && this.endDate.isAfter(this.maxDate))
                 this.endDate = this.maxDate.clone();
-  
+
             if (this.dateLimit && this.startDate.clone().add(this.dateLimit).isBefore(this.endDate))
                 this.endDate = this.startDate.clone().add(this.dateLimit);
-  
+
             this.previousRightTime = this.endDate.clone();
-  
+
             if (!this.isShowing)
                 this.updateElement();
-  
+
             this.updateMonthsInView();
         },
-  
+
         isInvalidDate: function() {
             return false;
         },
-  
+
         isCustomDate: function() {
             return false;
         },
-  
+
         updateView: function() {
             if (this.timePicker) {
                 this.renderTimePicker('left');
@@ -571,10 +571,10 @@
             this.updateCalendars();
             this.updateFormInputs();
         },
-  
+
         updateMonthsInView: function() {
             if (this.endDate) {
-  
+
                 //if both dates are visible already, do nothing
                 if (!this.singleDatePicker && this.leftCalendar.month && this.rightCalendar.month &&
                     (this.startDate.format('YYYY-MM') == this.leftCalendar.month.format('YYYY-MM') || this.startDate.format('YYYY-MM') == this.rightCalendar.month.format('YYYY-MM'))
@@ -583,14 +583,14 @@
                     ) {
                     return;
                 }
-  
+
                 this.leftCalendar.month = this.startDate.clone().date(2);
                 if (!this.linkedCalendars && (this.endDate.month() != this.startDate.month() || this.endDate.year() != this.startDate.year())) {
                     this.rightCalendar.month = this.endDate.clone().date(2);
                 } else {
                     this.rightCalendar.month = this.startDate.clone().date(2).add(1, 'month');
                 }
-  
+
             } else {
                 if (this.leftCalendar.month.format('YYYY-MM') != this.startDate.format('YYYY-MM') && this.rightCalendar.month.format('YYYY-MM') != this.startDate.format('YYYY-MM')) {
                     this.leftCalendar.month = this.startDate.clone().date(2);
@@ -601,18 +601,17 @@
               this.rightCalendar.month = this.maxDate.clone().date(2);
               this.leftCalendar.month = this.maxDate.clone().date(2).subtract(1, 'month');
             }
-  
+
             // For non-linked date-range picker, if year-month of startDate, endDate and maxDate are same, then rendering that year-month in rightCalendar and showing previous month in leftCalendar for better UX.
             if(!this.linkedCalendars && !this.singleDatePicker && this.maxDate && this.startDate && this.endDate
-              && this.startDate.format('YYYY-MM') === this.endDate.format('YYYY-MM') && this.maxDate.format('YYYY-MM') === this.endDate.format('YYYY-MM')) {
-  
-              this.rightCalendar.month = this.maxDate.clone().date(2);
-              this.leftCalendar.month = this.maxDate.clone().date(2).subtract(1, 'month');
+                && this.startDate.format('YYYY-MM') === this.endDate.format('YYYY-MM') && this.maxDate.format('YYYY-MM') === this.endDate.format('YYYY-MM')) {
+                this.rightCalendar.month = this.maxDate.clone().date(2);
+                this.leftCalendar.month = this.maxDate.clone().date(2).subtract(1, 'month');
             }
         },
-  
+
         updateCalendars: function() {
-  
+
             if (this.timePicker) {
                 var hour, minute, second;
                 if (this.endDate) {
@@ -641,23 +640,23 @@
                 this.leftCalendar.month.hour(hour).minute(minute).second(second);
                 this.rightCalendar.month.hour(hour).minute(minute).second(second);
             }
-  
+
             this.renderCalendar('left');
             this.renderCalendar('right');
-  
+
             //highlight any predefined range matching the current start and end dates
             this.container.find('.ranges li').removeClass('active');
             if (this.endDate == null) return;
-  
+
             this.calculateChosenLabel();
         },
-  
+
         renderCalendar: function(side) {
-  
+
             //
             // Build the matrix of dates that will populate the calendar
             //
-  
+
             var calendar = side == 'left' ? this.leftCalendar : this.rightCalendar;
             var month = calendar.month.month();
             var year = calendar.month.year();
@@ -671,26 +670,26 @@
             var lastYear = moment(firstDay).subtract(1, 'month').year();
             var daysInLastMonth = moment([lastYear, lastMonth]).daysInMonth();
             var dayOfWeek = firstDay.day();
-  
+
             //initialize a 6 rows x 7 columns array for the calendar
             var calendar = [];
             calendar.firstDay = firstDay;
             calendar.lastDay = lastDay;
-  
+
             for (var i = 0; i < 6; i++) {
                 calendar[i] = [];
             }
-  
+
             //populate the calendar with date objects
             var startDay = daysInLastMonth - dayOfWeek + this.locale.firstDay + 1;
             if (startDay > daysInLastMonth)
                 startDay -= 7;
-  
+
             if (dayOfWeek == this.locale.firstDay)
                 startDay = daysInLastMonth - 6;
-  
+
             var curDate = moment([lastYear, lastMonth, startDay, 12, minute, second]);
-  
+
             var col, row;
             for (var i = 0, col = 0, row = 0; i < 42; i++, col++, curDate = moment(curDate).add(24, 'hour')) {
                 if (i > 0 && col % 7 === 0) {
@@ -699,49 +698,49 @@
                 }
                 calendar[row][col] = curDate.clone().hour(hour).minute(minute).second(second);
                 curDate.hour(12);
-  
+
                 if (this.minDate && calendar[row][col].format('YYYY-MM-DD') == this.minDate.format('YYYY-MM-DD') && calendar[row][col].isBefore(this.minDate) && side == 'left') {
                     calendar[row][col] = this.minDate.clone();
                 }
-  
+
                 if (this.maxDate && calendar[row][col].format('YYYY-MM-DD') == this.maxDate.format('YYYY-MM-DD') && calendar[row][col].isAfter(this.maxDate) && side == 'right') {
                     calendar[row][col] = this.maxDate.clone();
                 }
-  
+
             }
-  
+
             //make the calendar object available to hoverDate/clickDate
             if (side == 'left') {
                 this.leftCalendar.calendar = calendar;
             } else {
                 this.rightCalendar.calendar = calendar;
             }
-  
+
             //
             // Display the calendar
             //
-  
+
             var minDate = side == 'left' ? this.minDate : this.startDate;
             var maxDate = this.maxDate;
             var selected = side == 'left' ? this.startDate : this.endDate;
             var arrow = this.locale.direction == 'ltr' ? {left: 'chevron-left', right: 'chevron-right'} : {left: 'chevron-right', right: 'chevron-left'};
-  
+
             var html = '<table class="table-condensed">';
             html += '<thead>';
             html += '<tr>';
-  
+
             // add empty cell for week number
             if (this.showWeekNumbers || this.showISOWeekNumbers)
                 html += '<th></th>';
-  
+
             if ((!minDate || minDate.isBefore(calendar.firstDay)) && (!this.linkedCalendars || side == 'left')) {
                 html += '<th class="prev available"><i class="fa fa-' + arrow.left + ' glyphicon glyphicon-' + arrow.left + '"></i></th>';
             } else {
                 html += '<th></th>';
             }
-  
+
             var dateHtml = this.locale.monthNames[calendar[1][1].month()] + calendar[1][1].format(" YYYY");
-  
+
             if (this.showDropdowns) {
                 var currentMonth = calendar[1][1].month();
                 var currentYear = calendar[1][1].year();
@@ -749,7 +748,7 @@
                 var minYear = (minDate && minDate.year()) || (currentYear - 50);
                 var inMinYear = currentYear == minYear;
                 var inMaxYear = currentYear == maxYear;
-  
+
                 var monthHtml = '<select class="monthselect">';
                 for (var m = 0; m < 12; m++) {
                     if ((!inMinYear || m >= minDate.month()) && (!inMaxYear || m <= maxDate.month())) {
@@ -763,7 +762,7 @@
                     }
                 }
                 monthHtml += "</select>";
-  
+
                 var yearHtml = '<select class="yearselect">';
                 for (var y = minYear; y <= maxYear; y++) {
                     yearHtml += '<option value="' + y + '"' +
@@ -771,32 +770,32 @@
                         '>' + y + '</option>';
                 }
                 yearHtml += '</select>';
-  
+
                 dateHtml = monthHtml + yearHtml;
             }
-  
+
             html += '<th colspan="5" class="month">' + dateHtml + '</th>';
             if ((!maxDate || maxDate.isAfter(calendar.lastDay)) && (!this.linkedCalendars || side == 'right' || this.singleDatePicker)) {
                 html += '<th class="next available"><i class="fa fa-' + arrow.right + ' glyphicon glyphicon-' + arrow.right + '"></i></th>';
             } else {
                 html += '<th></th>';
             }
-  
+
             html += '</tr>';
             html += '<tr>';
-  
+
             // add week number label
             if (this.showWeekNumbers || this.showISOWeekNumbers)
                 html += '<th class="week">' + this.locale.weekLabel + '</th>';
-  
+
             $.each(this.locale.daysOfWeek, function(index, dayOfWeek) {
                 html += '<th>' + dayOfWeek + '</th>';
             });
-  
+
             html += '</tr>';
             html += '</thead>';
             html += '<tbody>';
-  
+
             //adjust maxDate to reflect the dateLimit setting in order to
             //grey out end dates beyond the dateLimit
             if (this.endDate == null && this.dateLimit) {
@@ -805,56 +804,56 @@
                     maxDate = maxLimit;
                 }
             }
-  
+
             for (var row = 0; row < 6; row++) {
                 html += '<tr>';
-  
+
                 // add week number
                 if (this.showWeekNumbers)
                     html += '<td class="week">' + calendar[row][0].week() + '</td>';
                 else if (this.showISOWeekNumbers)
                     html += '<td class="week">' + calendar[row][0].isoWeek() + '</td>';
-  
+
                 for (var col = 0; col < 7; col++) {
-  
+
                     var classes = [];
-  
+
                     //highlight today's date
                     if (calendar[row][col].isSame(new Date(), "day"))
                         classes.push('today');
-  
+
                     //highlight weekends
                     if (calendar[row][col].isoWeekday() > 5)
                         classes.push('weekend');
-  
+
                     //grey out the dates in other months displayed at beginning and end of this calendar
                     if (calendar[row][col].month() != calendar[1][1].month())
                         classes.push('off');
-  
+
                     //don't allow selection of dates before the minimum date
                     if (this.minDate && calendar[row][col].isBefore(this.minDate, 'day'))
                         classes.push('off', 'disabled');
-  
+
                     //don't allow selection of dates after the maximum date
                     if (maxDate && calendar[row][col].isAfter(maxDate, 'day'))
                         classes.push('off', 'disabled');
-  
+
                     //don't allow selection of date if a custom function decides it's invalid
                     if (this.isInvalidDate(calendar[row][col]))
                         classes.push('off', 'disabled');
-  
+
                     //highlight the currently selected start date
                     if (calendar[row][col].format('YYYY-MM-DD') == this.startDate.format('YYYY-MM-DD'))
                         classes.push('active', 'start-date');
-  
+
                     //highlight the currently selected end date
                     if (this.endDate != null && calendar[row][col].format('YYYY-MM-DD') == this.endDate.format('YYYY-MM-DD'))
                         classes.push('active', 'end-date');
-  
+
                     //highlight dates in-between the selected dates
                     if (this.endDate != null && calendar[row][col] > this.startDate && calendar[row][col] < this.endDate)
                         classes.push('in-range');
-  
+
                     //apply custom classes for this date
                     var isCustom = this.isCustomDate(calendar[row][col]);
                     if (isCustom !== false) {
@@ -863,7 +862,7 @@
                         else
                             Array.prototype.push.apply(classes, isCustom);
                     }
-  
+
                     var cname = '', disabled = false;
                     for (var i = 0; i < classes.length; i++) {
                         cname += classes[i] + ' ';
@@ -872,46 +871,46 @@
                     }
                     if (!disabled)
                         cname += 'available';
-  
+
                     html += '<td class="' + cname.replace(/^\s+|\s+$/g, '') + '" data-title="' + 'r' + row + 'c' + col + '">' + calendar[row][col].date() + '</td>';
-  
+
                 }
                 html += '</tr>';
             }
-  
+
             html += '</tbody>';
             html += '</table>';
-  
+
             this.container.find('.calendar.' + side + ' .calendar-table').html(html);
-  
+
         },
-  
+
         renderTimePicker: function(side) {
-  
+
             // Don't bother updating the time picker if it's currently disabled
             // because an end date hasn't been clicked yet
             if (side == 'right' && !this.endDate) return;
-  
+
             var html, selected, minDate, maxDate = this.maxDate;
-  
+
             if (this.dateLimit && (!this.maxDate || this.startDate.clone().add(this.dateLimit).isAfter(this.maxDate)))
                 maxDate = this.startDate.clone().add(this.dateLimit);
-  
+
             if (side == 'left') {
                 selected = this.startDate.clone();
                 minDate = this.minDate;
             } else if (side == 'right') {
                 selected = this.endDate.clone();
                 minDate = this.startDate;
-  
+
                 //Preserve the time already selected
                 var timeSelector = this.container.find('.calendar.right .calendar-time div');
                 if (timeSelector.html() != '') {
-  
+
                     selected.hour(timeSelector.find('.hourselect option:selected').val() || selected.hour());
                     selected.minute(timeSelector.find('.minuteselect option:selected').val() || selected.minute());
                     selected.second(timeSelector.find('.secondselect option:selected').val() || selected.second());
-  
+
                     if (!this.timePicker24Hour) {
                         var ampm = timeSelector.find('.ampmselect option:selected').val();
                         if (ampm === 'PM' && selected.hour() < 12)
@@ -919,38 +918,38 @@
                         if (ampm === 'AM' && selected.hour() === 12)
                             selected.hour(0);
                     }
-  
+
                 }
-  
+
                 if (selected.isBefore(this.startDate))
                     selected = this.startDate.clone();
-  
+
                 if (maxDate && selected.isAfter(maxDate))
                     selected = maxDate.clone();
-  
+
             }
-  
+
             //
             // hours
             //
-  
+
             html = '<select class="hourselect">';
-  
+
             var start = this.timePicker24Hour ? 0 : 1;
             var end = this.timePicker24Hour ? 23 : 12;
-  
+
             for (var i = start; i <= end; i++) {
                 var i_in_24 = i;
                 if (!this.timePicker24Hour)
                     i_in_24 = selected.hour() >= 12 ? (i == 12 ? 12 : i + 12) : (i == 12 ? 0 : i);
-  
+
                 var time = selected.clone().hour(i_in_24);
                 var disabled = false;
                 if (minDate && time.minute(59).isBefore(minDate))
                     disabled = true;
                 if (maxDate && time.minute(0).isAfter(maxDate))
                     disabled = true;
-  
+
                 if (i_in_24 == selected.hour() && !disabled) {
                     html += '<option value="' + i + '" selected="selected">' + i + '</option>';
                 } else if (disabled) {
@@ -959,25 +958,25 @@
                     html += '<option value="' + i + '">' + i + '</option>';
                 }
             }
-  
+
             html += '</select> ';
-  
+
             //
             // minutes
             //
-  
+
             html += ': <select class="minuteselect">';
-  
+
             for (var i = 0; i < 60; i += this.timePickerIncrement) {
                 var padded = i < 10 ? '0' + i : i;
                 var time = selected.clone().minute(i);
-  
+
                 var disabled = false;
                 if (minDate && time.second(59).isBefore(minDate))
                     disabled = true;
                 if (maxDate && time.second(0).isAfter(maxDate))
                     disabled = true;
-  
+
                 if (selected.minute() == i && !disabled) {
                     html += '<option value="' + i + '" selected="selected">' + padded + '</option>';
                 } else if (disabled) {
@@ -986,26 +985,26 @@
                     html += '<option value="' + i + '">' + padded + '</option>';
                 }
             }
-  
+
             html += '</select> ';
-  
+
             //
             // seconds
             //
-  
+
             if (this.timePickerSeconds) {
                 html += ': <select class="secondselect">';
-  
+
                 for (var i = 0; i < 60; i++) {
                     var padded = i < 10 ? '0' + i : i;
                     var time = selected.clone().second(i);
-  
+
                     var disabled = false;
                     if (minDate && time.isBefore(minDate))
                         disabled = true;
                     if (maxDate && time.isAfter(maxDate))
                         disabled = true;
-  
+
                     if (selected.second() == i && !disabled) {
                         html += '<option value="' + i + '" selected="selected">' + padded + '</option>';
                     } else if (disabled) {
@@ -1014,57 +1013,57 @@
                         html += '<option value="' + i + '">' + padded + '</option>';
                     }
                 }
-  
+
                 html += '</select> ';
             }
-  
+
             //
             // AM/PM
             //
-  
+
             if (!this.timePicker24Hour) {
                 html += '<select class="ampmselect">';
-  
+
                 var am_html = '';
                 var pm_html = '';
-  
+
                 if (minDate && selected.clone().hour(12).minute(0).second(0).isBefore(minDate))
                     am_html = ' disabled="disabled" class="disabled"';
-  
+
                 if (maxDate && selected.clone().hour(0).minute(0).second(0).isAfter(maxDate))
                     pm_html = ' disabled="disabled" class="disabled"';
-  
+
                 if (selected.hour() >= 12) {
                     html += '<option value="AM"' + am_html + '>AM</option><option value="PM" selected="selected"' + pm_html + '>PM</option>';
                 } else {
                     html += '<option value="AM" selected="selected"' + am_html + '>AM</option><option value="PM"' + pm_html + '>PM</option>';
                 }
-  
+
                 html += '</select>';
             }
-  
+
             this.container.find('.calendar.' + side + ' .calendar-time div').html(html);
-  
+
         },
-  
+
         updateFormInputs: function() {
-  
+
             //ignore mouse movements while an above-calendar text input has focus
             if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
                 return;
-  
+
             this.container.find('input[name=daterangepicker_start]').val(this.startDate.format(this.locale.format));
             if (this.endDate)
                 this.container.find('input[name=daterangepicker_end]').val(this.endDate.format(this.locale.format));
-  
+
             if (this.singleDatePicker || (this.endDate && (this.startDate.isBefore(this.endDate) || this.startDate.isSame(this.endDate)))) {
                 this.container.find('button.applyBtn').removeAttr('disabled');
             } else {
                 this.container.find('button.applyBtn').attr('disabled', 'disabled');
             }
-  
+
         },
-  
+
         move: function() {
             var parentOffset = { top: 0, left: 0 },
                 containerTop;
@@ -1076,13 +1075,13 @@
                 };
                 parentRightEdge = this.parentEl[0].clientWidth + this.parentEl.offset().left;
             }
-  
+
             if (this.drops == 'up')
                 containerTop = this.element.offset().top - this.container.outerHeight() - parentOffset.top;
             else
                 containerTop = this.element.offset().top + this.element.outerHeight() - parentOffset.top;
             this.container[this.drops == 'up' ? 'addClass' : 'removeClass']('dropup');
-  
+
             if (this.opens == 'left') {
                 this.container.css({
                     top: containerTop,
@@ -1122,13 +1121,13 @@
                 }
             }
         },
-  
+
         show: function(e) {
             if (this.isShowing) return;
-  
+
             // Create a click proxy that is private to this instance of datepicker, for unbinding
             this._outsideClickProxy = $.proxy(function(e) { this.outsideClick(e); }, this);
-  
+
             // Bind global datepicker mousedown for hiding and
             $(document)
               .on('mousedown.daterangepicker', this._outsideClickProxy)
@@ -1138,44 +1137,44 @@
               .on('click.daterangepicker', '[data-toggle=dropdown]', this._outsideClickProxy)
               // and also close when focus changes to outside the picker (eg. tabbing between controls)
               .on('focusin.daterangepicker', this._outsideClickProxy);
-  
+
             // Reposition the picker if the window is resized while it's open
             $(window).on('resize.daterangepicker', $.proxy(function(e) { this.move(e); }, this));
-  
+
             this.oldStartDate = this.startDate.clone();
             this.oldEndDate = this.endDate.clone();
             this.previousRightTime = this.endDate.clone();
-  
+
             this.updateView();
             this.container.show();
             this.move();
             this.element.trigger('show.daterangepicker', this);
             this.isShowing = true;
         },
-  
+
         hide: function(e) {
             if (!this.isShowing) return;
-  
+
             //incomplete date selection, revert to last values
             if (!this.endDate) {
                 this.startDate = this.oldStartDate.clone();
                 this.endDate = this.oldEndDate.clone();
             }
-  
+
             //if a new date range was selected, invoke the user callback function
             if (!this.startDate.isSame(this.oldStartDate) || !this.endDate.isSame(this.oldEndDate) || this.emitChangeOnSameDate)
                 this.callback(this.startDate, this.endDate, this.chosenLabel);
-  
+
             //if picker is attached to a text input, update it
             this.updateElement();
-  
+
             $(document).off('.daterangepicker');
             $(window).off('.daterangepicker');
             this.container.hide();
             this.element.trigger('hide.daterangepicker', this);
             this.isShowing = false;
         },
-  
+
         toggle: function(e) {
             if (this.isShowing) {
                 this.hide();
@@ -1183,7 +1182,7 @@
                 this.show();
             }
         },
-  
+
         outsideClick: function(e) {
             var target = $(e.target);
             // if the page is clicked anywhere except within the daterangerpicker/button
@@ -1198,26 +1197,26 @@
             this.hide();
             this.element.trigger('outsideClick.daterangepicker', this);
         },
-  
+
         showCalendars: function() {
             this.container.addClass('show-calendar');
             this.move();
             this.element.trigger('showCalendar.daterangepicker', this);
         },
-  
+
         hideCalendars: function() {
             this.container.removeClass('show-calendar');
             this.element.trigger('hideCalendar.daterangepicker', this);
         },
-  
+
         hoverRange: function(e) {
-  
+
             //ignore mouse movements while an above-calendar text input has focus
             if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
                 return;
-  
+
             var label = e.target.getAttribute('data-range-key');
-  
+
             if (label == this.locale.customRangeLabel) {
                 this.updateView();
             } else {
@@ -1225,9 +1224,9 @@
                 this.container.find('input[name=daterangepicker_start]').val(dates[0].format(this.locale.format));
                 this.container.find('input[name=daterangepicker_end]').val(dates[1].format(this.locale.format));
             }
-  
+
         },
-  
+
         clickRange: function(e) {
             var label = e.target.getAttribute('data-range-key');
             this.chosenLabel = label;
@@ -1237,18 +1236,18 @@
                 var dates = this.ranges[label];
                 this.startDate = dates[0];
                 this.endDate = dates[1];
-  
+
                 if (!this.timePicker) {
                     this.startDate.startOf('day');
                     this.endDate.endOf('day');
                 }
-  
+
                 if (!this.alwaysShowCalendars)
                     this.hideCalendars();
                 this.clickApply();
             }
         },
-  
+
         clickPrev: function(e) {
             var cal = $(e.target).parents('.calendar');
             if (cal.hasClass('left')) {
@@ -1260,7 +1259,7 @@
             }
             this.updateCalendars();
         },
-  
+
         clickNext: function(e) {
             var cal = $(e.target).parents('.calendar');
             if (cal.hasClass('left')) {
@@ -1272,66 +1271,66 @@
             }
             this.updateCalendars();
         },
-  
+
         hoverDate: function(e) {
-  
+
             //ignore mouse movements while an above-calendar text input has focus
             //if (this.container.find('input[name=daterangepicker_start]').is(":focus") || this.container.find('input[name=daterangepicker_end]').is(":focus"))
             //    return;
-  
+
             //ignore dates that can't be selected
             if (!$(e.target).hasClass('available')) return;
-  
+
             //have the text inputs above calendars reflect the date being hovered over
             var title = $(e.target).attr('data-title');
             var row = title.substr(1, 1);
             var col = title.substr(3, 1);
             var cal = $(e.target).parents('.calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
-  
+
             if (this.endDate && !this.container.find('input[name=daterangepicker_start]').is(":focus")) {
                 this.container.find('input[name=daterangepicker_start]').val(date.format(this.locale.format));
             } else if (!this.endDate && !this.container.find('input[name=daterangepicker_end]').is(":focus")) {
                 this.container.find('input[name=daterangepicker_end]').val(date.format(this.locale.format));
             }
-  
+
             //highlight the dates between the start date and the date being hovered as a potential end date
             var leftCalendar = this.leftCalendar;
             var rightCalendar = this.rightCalendar;
             var startDate = this.startDate;
             if (!this.endDate) {
                 this.container.find('.calendar tbody td').each(function(index, el) {
-  
+
                     //skip week numbers, only look at dates
                     if ($(el).hasClass('week')) return;
-  
+
                     var title = $(el).attr('data-title');
                     var row = title.substr(1, 1);
                     var col = title.substr(3, 1);
                     var cal = $(el).parents('.calendar');
                     var dt = cal.hasClass('left') ? leftCalendar.calendar[row][col] : rightCalendar.calendar[row][col];
-  
+
                     if ((dt.isAfter(startDate) && dt.isBefore(date)) || dt.isSame(date, 'day')) {
                         $(el).addClass('in-range');
                     } else {
                         $(el).removeClass('in-range');
                     }
-  
+
                 });
             }
-  
+
         },
-  
+
         clickDate: function(e) {
-  
+
             if (!$(e.target).hasClass('available')) return;
-  
+
             var title = $(e.target).attr('data-title');
             var row = title.substr(1, 1);
             var col = title.substr(3, 1);
             var cal = $(e.target).parents('.calendar');
             var date = cal.hasClass('left') ? this.leftCalendar.calendar[row][col] : this.rightCalendar.calendar[row][col];
-  
+
             //
             // this function needs to do a few things:
             // * alternate between selecting a start and end date for the range,
@@ -1340,7 +1339,7 @@
             // * if single date picker mode, and time picker isn't enabled, apply the selection immediately
             // * if one of the inputs above the calendars was focused, cancel that manual input
             //
-  
+
             if (this.endDate || date.isBefore(this.startDate, 'day')) { //picking start
                 if (this.timePicker) {
                     var hour = parseInt(this.container.find('.left .hourselect').val(), 10);
@@ -1381,20 +1380,20 @@
                   this.clickApply();
                 }
             }
-  
+
             if (this.singleDatePicker) {
                 this.setEndDate(this.startDate);
                 if (!this.timePicker)
                     this.clickApply();
             }
-  
+
             this.updateView();
-  
+
             //This is to cancel the blur event handler if the mouse was in one of the inputs
             e.stopPropagation();
-  
+
         },
-  
+
         calculateChosenLabel: function () {
             var customRange = true;
             var i = 0;
@@ -1424,49 +1423,49 @@
                 this.showCalendars();
             }
         },
-  
+
         clickApply: function(e) {
             this.hide();
             this.element.trigger('apply.daterangepicker', this);
         },
-  
+
         clickCancel: function(e) {
             this.startDate = this.oldStartDate;
             this.endDate = this.oldEndDate;
             this.hide();
             this.element.trigger('cancel.daterangepicker', this);
         },
-  
+
         monthOrYearChanged: function(e) {
             var isLeft = $(e.target).closest('.calendar').hasClass('left'),
                 leftOrRight = isLeft ? 'left' : 'right',
                 cal = this.container.find('.calendar.'+leftOrRight);
-  
+
             // Month must be Number for new moment versions
             var month = parseInt(cal.find('.monthselect').val(), 10);
             var year = cal.find('.yearselect').val();
-  
+
             if (!isLeft) {
                 if (year < this.startDate.year() || (year == this.startDate.year() && month < this.startDate.month())) {
                     month = this.startDate.month();
                     year = this.startDate.year();
                 }
             }
-  
+
             if (this.minDate) {
                 if (year < this.minDate.year() || (year == this.minDate.year() && month < this.minDate.month())) {
                     month = this.minDate.month();
                     year = this.minDate.year();
                 }
             }
-  
+
             if (this.maxDate) {
                 if (year > this.maxDate.year() || (year == this.maxDate.year() && month > this.maxDate.month())) {
                     month = this.maxDate.month();
                     year = this.maxDate.year();
                 }
             }
-  
+
             if (isLeft) {
                 this.leftCalendar.month.month(month).year(year);
                 if (this.linkedCalendars)
@@ -1478,16 +1477,16 @@
             }
             this.updateCalendars();
         },
-  
+
         timeChanged: function(e) {
-  
+
             var cal = $(e.target).closest('.calendar'),
                 isLeft = cal.hasClass('left');
-  
+
             var hour = parseInt(cal.find('.hourselect').val(), 10);
             var minute = parseInt(cal.find('.minuteselect').val(), 10);
             var second = this.timePickerSeconds ? parseInt(cal.find('.secondselect').val(), 10) : 0;
-  
+
             if (!this.timePicker24Hour) {
                 var ampm = cal.find('.ampmselect').val();
                 if (ampm === 'PM' && hour < 12)
@@ -1495,7 +1494,7 @@
                 if (ampm === 'AM' && hour === 12)
                     hour = 0;
             }
-  
+
             if (isLeft) {
                 var start = this.startDate.clone();
                 start.hour(hour);
@@ -1514,50 +1513,50 @@
                 end.second(second);
                 this.setEndDate(end);
             }
-  
+
             //update the calendars so all clickable dates reflect the new time component
             this.updateCalendars();
-  
+
             //update the form inputs above the calendars with the new time
             this.updateFormInputs();
-  
+
             //re-render the time pickers because changing one selection can affect what's enabled in another
             this.renderTimePicker('left');
             this.renderTimePicker('right');
-  
+
         },
-  
+
         formInputsChanged: function(e) {
             var isRight = $(e.target).closest('.calendar').hasClass('right');
             var start = moment(this.container.find('input[name="daterangepicker_start"]').val(), this.locale.format);
             var end = moment(this.container.find('input[name="daterangepicker_end"]').val(), this.locale.format);
-  
+
             if (start.isValid() && end.isValid()) {
-  
+
                 if (isRight && end.isBefore(start))
                     start = end.clone();
-  
+
                 this.setStartDate(start);
                 this.setEndDate(end);
-  
+
                 if (isRight) {
                     this.container.find('input[name="daterangepicker_start"]').val(this.startDate.format(this.locale.format));
                 } else {
                     this.container.find('input[name="daterangepicker_end"]').val(this.endDate.format(this.locale.format));
                 }
-  
+
             }
-  
+
             this.updateView();
         },
-  
+
         formInputsFocused: function(e) {
-  
+
             // Highlight the focused input
             this.container.find('input[name="daterangepicker_start"], input[name="daterangepicker_end"]').removeClass('active');
             $(e.target).addClass('active');
-  
-            // Set the state such that if the user goes back to using a mouse,
+
+            // Set the state such that if the user goes back to using a mouse, 
             // the calendars are aware we're selecting the end of the range, not
             // the start. This allows someone to edit the end of a date range without
             // re-selecting the beginning, by clicking on the end date input then
@@ -1568,16 +1567,16 @@
                 this.setStartDate(this.startDate.clone());
                 this.updateView();
             }
-  
+
         },
-  
+
         formInputsBlurred: function(e) {
-  
+
             // this function has one purpose right now: if you tab from the first
             // text input to the second in the UI, the endDate is nulled so that
             // you can click another, but if you tab out without clicking anything
             // or changing the input value, the old endDate should be retained
-  
+
             if (!this.endDate) {
                 var val = this.container.find('input[name="daterangepicker_end"]').val();
                 var end = moment(val, this.locale.format);
@@ -1586,42 +1585,42 @@
                     this.updateView();
                 }
             }
-  
+
         },
-  
+
         elementChanged: function() {
             if (!this.element.is('input')) return;
             if (!this.element.val().length) return;
             if (this.element.val().length < this.locale.format.length) return;
-  
+
             var dateString = this.element.val().split(this.locale.separator),
                 start = null,
                 end = null;
-  
+
             if (dateString.length === 2) {
                 start = moment(dateString[0], this.locale.format);
                 end = moment(dateString[1], this.locale.format);
             }
-  
+
             if (this.singleDatePicker || start === null || end === null) {
                 start = moment(this.element.val(), this.locale.format);
                 end = start;
             }
-  
+
             if (!start.isValid() || !end.isValid()) return;
-  
+
             this.setStartDate(start);
             this.setEndDate(end);
             this.updateView();
         },
-  
+
         keydown: function(e) {
             //hide on tab or enter
             if ((e.keyCode === 9) || (e.keyCode === 13)) {
                 this.hide();
             }
         },
-  
+
         updateElement: function() {
             if (this.element.is('input') && !this.singleDatePicker && this.autoUpdateInput) {
                 this.element.val(this.startDate.format(this.locale.format) + this.locale.separator + this.endDate.format(this.locale.format));
@@ -1631,15 +1630,15 @@
                 this.element.trigger('change');
             }
         },
-  
+
         remove: function() {
             this.container.remove();
             this.element.off('.daterangepicker');
             this.element.removeData();
         }
-  
+
     };
-  
+
     $.fn.daterangepicker = function(options, callback) {
         this.each(function() {
             var el = $(this);
@@ -1649,8 +1648,7 @@
         });
         return this;
     };
-  
+
     return DateRangePicker;
-  
-  }));
-  
+
+}));


### PR DESCRIPTION
In current implementation, for non-linked date-range picker, if startDate, endDate and maxDate fall in same month-year then that month-year is being shown in left-calendar as shown below:
![current-behaviour](https://user-images.githubusercontent.com/4411891/38354035-d404c15e-38d5-11e8-8937-b92069837c29.png)

But as max date is in same month, it is better to show previous month in left-calendar and endDate month-year in right-calendar to reduce some clicks and thereby to improve UX. This PR implements that changes and the date-range picker will look as shown below in this case.
![new-behaviour](https://user-images.githubusercontent.com/4411891/38354142-24260936-38d6-11e8-957a-5af5bd9e01f8.png)

Let me know in case of any issue.

Thanks

